### PR TITLE
Update test mapping for version compatible

### DIFF
--- a/src/main/scala/org/elasticsearch/client/http/ESHttpClient.scala
+++ b/src/main/scala/org/elasticsearch/client/http/ESHttpClient.scala
@@ -134,13 +134,21 @@ class ESHttpClient(servers: Seq[String], authInfo: AuthInfo) {
   }
 
   def indexExist(index: String) : Boolean = {
-    val resp = client.performRequest(HttpHead.METHOD_NAME, s"$index")
+    val resp = client.performRequest(HttpHead.METHOD_NAME, s"/$index")
     resp.getStatusLine.getStatusCode match {
       case 200 => true
       case 404 => false
       case _ =>
         //TODO: Should we handle others code?
         throw new Exception("Invalid http response code")
+    }
+  }
+
+  def refresh(indies: Set[String]): Unit = {
+    val resp = client.performRequest(HttpPost.METHOD_NAME, s"/${indies.mkString(",")}/_refresh")
+    resp.getStatusLine.getStatusCode match {
+      case 200 => true
+      case code => throw new Exception(s"Refresh topic return code $code")
     }
   }
 

--- a/src/main/scala/org/elasticsearch/client/http/ESHttpClient.scala
+++ b/src/main/scala/org/elasticsearch/client/http/ESHttpClient.scala
@@ -43,16 +43,16 @@ class ESHttpClient(servers: Seq[String], authInfo: AuthInfo) {
     builder.build()
   }
 
-  private val versionInfo = {
+  val clusterInfo: ClusterInfo = {
     val resp = client.performRequest(HttpGet.METHOD_NAME, "/", Map.empty[String, String])
     objectMapper.readValue(resp.getEntity.getContent, classOf[ClusterInfo])
   }
 
   logger.info("===============================================")
   logger.info("Cluster basic information:")
-  logger.info(s"Cluster name:     ${versionInfo.clusterName}")
-  logger.info(s"ES version:       ${versionInfo.version.number}")
-  logger.info(s"Lucene version:   ${versionInfo.version.luceneVersion}")
+  logger.info(s"Cluster name:     ${clusterInfo.clusterName}")
+  logger.info(s"ES version:       ${clusterInfo.version.number}")
+  logger.info(s"Lucene version:   ${clusterInfo.version.luceneVersion}")
   logger.info("===============================================")
 
 

--- a/src/test/resources/org/elasticsearch/search/query/all-query-index-lt5.json
+++ b/src/test/resources/org/elasticsearch/search/query/all-query-index-lt5.json
@@ -9,7 +9,7 @@
     "doc": {
       "properties": {
         "f1": {"type": "string"},
-        "f2": {"type": "keyword"},
+        "f2": {"type": "string", "index": "not_analyzed"},
         "f3": {"type": "string"},
         "f4": {
           "type": "string",
@@ -18,7 +18,7 @@
         "f_multi": {
           "type": "string",
           "fields": {
-            "raw": {"type": "keyword"},
+            "raw": {"type": "string", "index": "not_analyzed"},
             "f_token_count": {"type": "token_count", "analyzer": "standard"}
           }
         },
@@ -26,7 +26,7 @@
           "type": "object",
           "properties": {
             "sub1": {"type": "string"},
-            "sub2": {"type": "keyword"},
+            "sub2": {"type": "string", "index": "not_analyzed"},
             "sub3": {"type": "integer"}
           }
         },
@@ -34,7 +34,7 @@
           "type": "nested",
           "properties": {
             "nest1": {"type": "string"},
-            "nest2": {"type": "keyword"},
+            "nest2": {"type": "string", "index": "not_analyzed"},
             "nest3": {"type": "integer"}
           }
         },

--- a/src/test/resources/org/elasticsearch/search/query/all-query-index-lt5.json
+++ b/src/test/resources/org/elasticsearch/search/query/all-query-index-lt5.json
@@ -1,0 +1,59 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+    }
+  },
+  "mappings": {
+    "doc": {
+      "properties": {
+        "f1": {"type": "string"},
+        "f2": {"type": "keyword"},
+        "f3": {"type": "string"},
+        "f4": {
+          "type": "string",
+          "index_options": "docs"
+        },
+        "f_multi": {
+          "type": "string",
+          "fields": {
+            "raw": {"type": "keyword"},
+            "f_token_count": {"type": "token_count", "analyzer": "standard"}
+          }
+        },
+        "f_object": {
+          "type": "object",
+          "properties": {
+            "sub1": {"type": "string"},
+            "sub2": {"type": "keyword"},
+            "sub3": {"type": "integer"}
+          }
+        },
+        "f_nested": {
+          "type": "nested",
+          "properties": {
+            "nest1": {"type": "string"},
+            "nest2": {"type": "keyword"},
+            "nest3": {"type": "integer"}
+          }
+        },
+        "f_date": {
+          "type": "date",
+          "format": "yyyy/MM/dd||epoch_millis"
+        },
+        "f_bool": {"type": "boolean"},
+        "f_byte": {"type": "byte"},
+        "f_short": {"type": "short"},
+        "f_int": {"type": "integer"},
+        "f_long": {"type": "long"},
+        "f_float": {"type": "float"},
+        "f_ip": {"type": "ip"},
+        "f_binary": {"type": "binary"},
+        "f_suggest": {"type": "completion"},
+        "f_geop": {"type": "geo_point"},
+        "f_geos": {"type": "geo_shape"}
+      }
+    }
+  }
+}

--- a/src/test/scala/org/elasticsearch/client/http/ApiEntitiesTest.scala
+++ b/src/test/scala/org/elasticsearch/client/http/ApiEntitiesTest.scala
@@ -1,0 +1,87 @@
+package org.elasticsearch.client.http
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.elasticsearch.client.http.entities.SearchResponse
+import org.scalatest.FunSuite
+
+/**
+  * Created by 51103 on 019, 19, 6, 2017.
+  */
+class ApiEntitiesTest extends FunSuite {
+
+  val searchResponseStr =
+    """
+      |{
+      |  "took": 1,
+      |  "timed_out": false,
+      |  "_shards": {
+      |    "total": 1,
+      |    "successful": 1,
+      |    "failed": 0
+      |  },
+      |  "hits": {
+      |    "total": 1,
+      |    "max_score": 0.3247595,
+      |    "hits": [
+      |      {
+      |        "_score": 0.3247595,
+      |        "_type": "doc",
+      |        "_source": {
+      |          "f_suggest": {
+      |            "input": [
+      |              "Nevermind",
+      |              "Nirvana"
+      |            ],
+      |            "weight": 34
+      |          },
+      |          "f_multi": "Foo Bar Baz",
+      |          "f_bool": "true",
+      |          "f1": "foo",
+      |          "f_long": "42",
+      |          "f_date": "1476383971",
+      |          "f3": "foo bar baz",
+      |          "f_nested": {
+      |            "nest1": "nfoo",
+      |            "nest2": "nbar",
+      |            "nest3": 21
+      |          },
+      |          "f_object": {
+      |            "sub1": "sfoo",
+      |            "sub2": "sbar",
+      |            "sub3": 19
+      |          },
+      |          "f_binary": "VGhpcyBpcyBzb21lIGJpbmFyeSBkYXRhCg==",
+      |          "f_short": "23",
+      |          "f_byte": "7",
+      |          "f_ip": "127.0.0.1",
+      |          "f_geos": {
+      |            "type": "point",
+      |            "coordinates": [
+      |              -77.03653,
+      |              38.897676
+      |            ]
+      |          },
+      |          "f_float": "1.7",
+      |          "f_geop": "41.12,-71.34",
+      |          "f2": "Bar",
+      |          "f_int": "1293"
+      |        },
+      |        "_id": "1",
+      |        "_index": "test"
+      |      }
+      |    ]
+      |  }
+      |}
+    """.stripMargin
+
+  val objectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  test("Deserialize SearchResponse from String should return success value") {
+
+    val resp = objectMapper.readValue(searchResponseStr, classOf[SearchResponse])
+    assert(resp.hits.total  == 1)
+    assert(!resp.timeOut)
+    assert(resp.hits.maxScore == 0.3247595)
+  }
+}

--- a/src/test/scala/org/elasticsearch/client/http/EsHttpClientSearchTest.scala
+++ b/src/test/scala/org/elasticsearch/client/http/EsHttpClientSearchTest.scala
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.elasticsearch.client.http.entities.{BasicAuthInfo, NoAuth}
 import org.elasticsearch.index.query.QueryBuilders
+import org.elasticsearch.search.builder.SearchSourceBuilder
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterAllConfigMap, ConfigMap, FunSuite}
 
 import scala.io.Source
@@ -39,33 +40,33 @@ class EsHttpClientSearchTest extends FunSuite with BeforeAndAfterAll {
       }
     assert(client.createIndex(index, idxSetting).acknowledged)
     assert(client.index(index, `type`, Some(id), docBody).getId == "1")
-    var resp = client.search(index, `type`, QueryBuilders.queryStringQuery("foo").toString)
+    var resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("foo")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search("test" , "doc", QueryBuilders.queryStringQuery("Bar").toString)
+    resp = client.search("test" , "doc", SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("Bar")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("Baz").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("Baz")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("19").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("19")).toString)
     assert(resp.hits.total == 1L)
     // nested doesn't match because it's hidden
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("1476383971").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("1476383971")).toString)
     assert(resp.hits.total == 1L)
     // bool doesn't match
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("7").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("7")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("23").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("23")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("1293").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("1293")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("42").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("42")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("1.7").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("1.7")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("1.5").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("1.5")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("12.23").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("12.23")).toString)
     assert(resp.hits.total == 1L)
-    resp = client.search(index, `type`, QueryBuilders.queryStringQuery("127.0.0.1").toString)
+    resp = client.search(index, `type`, SearchSourceBuilder.searchSource().query(QueryBuilders.queryStringQuery("127.0.0.1")).toString)
     assert(resp.hits.total == 1L)
     // binary doesn't match
     // suggest doesn't match

--- a/src/test/scala/org/elasticsearch/client/http/EsHttpClientSearchTest.scala
+++ b/src/test/scala/org/elasticsearch/client/http/EsHttpClientSearchTest.scala
@@ -31,7 +31,12 @@ class EsHttpClientSearchTest extends FunSuite with BeforeAndAfterAll {
   test("test doc with all types should success") {
     val docBody = Source.fromURL(getClass.getResource("/org/elasticsearch/search/query/all-example-document.json")).mkString
     val id = "1"
-    val idxSetting = Source.fromURL(getClass.getResource("/org/elasticsearch/search/query/all-query-index.json")).mkString
+    val idxSetting =
+      if(client.clusterInfo.version.number.split("\\.")(0).toInt < 5) {
+        Source.fromURL(getClass.getResource("/org/elasticsearch/search/query/all-query-index-lt5.json")).mkString
+      }else{
+        Source.fromURL(getClass.getResource("/org/elasticsearch/search/query/all-query-index.json")).mkString
+      }
     assert(client.createIndex(index, idxSetting).acknowledged)
     assert(client.index(index, `type`, Some(id), docBody).getId == "1")
     var resp = client.search(index, `type`, QueryBuilders.queryStringQuery("foo").toString)


### PR DESCRIPTION
Elasticsearch version before 5.0 does not support types:
 - keyword
 - some float types

