### PR TITLE
Restructure response entities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.thanhtien522"
 
 name := "es-http-client"
 
-version := "0.1-beta"
+version := "0.2-SNAPSHOT"
 
 scalaVersion := "2.11.11"
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ scalaVersion := "2.11.11"
 
 libraryDependencies ++= Seq(
   "org.elasticsearch.client" % "rest" % "5.4.1",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.8",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.8",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.5",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.5",
   "org.elasticsearch" % "elasticsearch" %"2.4.1" % "test",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )

--- a/src/main/scala/com/github/thanhtien522/eshttpclient/entities/APIEntities.scala
+++ b/src/main/scala/com/github/thanhtien522/eshttpclient/entities/APIEntities.scala
@@ -1,7 +1,7 @@
 package com.github.thanhtien522.eshttpclient.entities
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonNaming}
 
 trait DocRequest {
@@ -92,14 +92,14 @@ case class SearchRequest(searchQuery: String, __index: Option[String] = None, __
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class GetRequest(__index: Option[String], __type: Option[String], __id: String)
 
 
 trait DocResponse
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class IndexResponse(__index: String, __type: String, __id: String, __version: Long, created: Boolean) extends DocResponse {
   def getIndex: String = __index
 
@@ -113,7 +113,7 @@ case class IndexResponse(__index: String, __type: String, __id: String, __versio
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class UpdateResponse(__index: String, __type: String, __id: String, __version: Long) extends DocResponse {
   def getIndex: String = __index
 
@@ -125,7 +125,7 @@ case class UpdateResponse(__index: String, __type: String, __id: String, __versi
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class DeleteResponse(__index: String, __type: String, __id: String, __version: Long, found: Boolean) extends DocResponse {
   def getIndex: String = __index
 
@@ -139,14 +139,14 @@ case class DeleteResponse(__index: String, __type: String, __id: String, __versi
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class BulkResponse(took: Long, items: Seq[BulkItemResponse])
 
 @JsonDeserialize(using = classOf[BulkItemResponseDeserializer])
 case class BulkItemResponse(actionType: String, response: DocResponse)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class GetResponse(__index: String, __type: String, __id: String, __version: Long, found: Boolean, __source: Map[String, Any]) {
   def getIndex: String = __index
 
@@ -163,15 +163,15 @@ case class GetResponse(__index: String, __type: String, __id: String, __version:
 case class MultiSearchResponse(responses: Seq[SearchResponse])
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class SearchResponse(timeOut: Boolean, took: Long, hits: SearchHits)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class SearchHits(total: Long, maxScore: Double, hits: Seq[SearchHit], aggregations: Map[String, Any])
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class SearchHit(__index: String, __type: String, __id: String, __score: Double, __source: Map[String, Any]) {
   def getIndex: String = __index
 
@@ -185,5 +185,5 @@ case class SearchHit(__index: String, __type: String, __id: String, __score: Dou
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class AckResponse(acknowledged: Boolean)

--- a/src/main/scala/com/github/thanhtien522/eshttpclient/entities/APIEntities.scala
+++ b/src/main/scala/com/github/thanhtien522/eshttpclient/entities/APIEntities.scala
@@ -98,8 +98,7 @@ case class SearchRequest(searchQuery: String, __index: Option[String] = None, __
 @JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class GetRequest(__index: Option[String], __type: Option[String], __id: String)
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
+@JsonDeserialize(using = classOf[ErrorDeserializer])
 case class Error(`type`: String, reason: String, causedBy: Error)
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/scala/com/github/thanhtien522/eshttpclient/entities/APIEntities.scala
+++ b/src/main/scala/com/github/thanhtien522/eshttpclient/entities/APIEntities.scala
@@ -178,7 +178,7 @@ case class DeleteResponse(override val __index: String,
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
-case class BulkResponse(took: Long, items: Seq[BulkItemResponse])
+case class BulkResponse(took: Long, errors: Boolean, items: Seq[BulkItemResponse])
 
 @JsonDeserialize(using = classOf[BulkItemResponseDeserializer])
 case class BulkItemResponse(actionType: String, response: AbstractDocResponse)

--- a/src/main/scala/com/github/thanhtien522/eshttpclient/entities/APIEntities.scala
+++ b/src/main/scala/com/github/thanhtien522/eshttpclient/entities/APIEntities.scala
@@ -16,6 +16,7 @@ trait DocRequest {
 
 /**
   * Index document request
+  *
   * @param __index optional index of request, the index can be specified by API path
   * @param __type  optional type of request, the type can be specified by API path
   * @param __id    id of document
@@ -37,6 +38,7 @@ case class DocIndexRequest(__index: Option[String], __type: Option[String], __id
 
 /**
   * Index document request
+  *
   * @param __index optional index of request, the index can be specified by API path
   * @param __type  optional type of request, the type can be specified by API path
   * @param __id    id of document
@@ -57,6 +59,7 @@ case class DocDeleteRequest(__index: Option[String], __type: Option[String], __i
 
 /**
   * Update document request
+  *
   * @param __index optional index of request, the index can be specified by API path
   * @param __type  optional type of request, the type can be specified by API path
   * @param __id    id of document
@@ -95,12 +98,34 @@ case class SearchRequest(searchQuery: String, __index: Option[String] = None, __
 @JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class GetRequest(__index: Option[String], __type: Option[String], __id: String)
 
-
-trait DocResponse
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
+case class Error(`type`: String, reason: String, causedBy: Error)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
-case class IndexResponse(__index: String, __type: String, __id: String, __version: Long, created: Boolean) extends DocResponse {
+abstract class BaseResponse(val status: Int, val error: Error)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
+abstract class AbstractDocResponse(val __index: String,
+                                   val __type: String,
+                                   val __id: String,
+                                   val __version: Long,
+                                   override val status: Int,
+                                   override val error: Error
+                                  ) extends BaseResponse(status, error)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
+case class IndexResponse(override val __index: String,
+                         override val __type: String,
+                         override val __id: String,
+                         override val __version: Long,
+                         created: Boolean,
+                         override val status: Int,
+                         override val error: Error
+                        ) extends AbstractDocResponse(__index, __type, __id, __version, status, error) {
   def getIndex: String = __index
 
   def getType: String = __type
@@ -114,7 +139,13 @@ case class IndexResponse(__index: String, __type: String, __id: String, __versio
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
-case class UpdateResponse(__index: String, __type: String, __id: String, __version: Long) extends DocResponse {
+case class UpdateResponse(override val __index: String,
+                          override val __type: String,
+                          override val __id: String,
+                          override val __version: Long,
+                          override val status: Int,
+                          override val error: Error
+                         ) extends AbstractDocResponse(__index, __type, __id, __version, status, error) {
   def getIndex: String = __index
 
   def getType: String = __type
@@ -126,7 +157,14 @@ case class UpdateResponse(__index: String, __type: String, __id: String, __versi
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
-case class DeleteResponse(__index: String, __type: String, __id: String, __version: Long, found: Boolean) extends DocResponse {
+case class DeleteResponse(override val __index: String,
+                          override val __type: String,
+                          override val __id: String,
+                          override val __version: Long,
+                          found: Boolean,
+                          override val status: Int,
+                          override val error: Error
+                         ) extends AbstractDocResponse(__index, __type, __id, __version, status, error) {
   def getIndex: String = __index
 
   def getType: String = __type
@@ -143,7 +181,7 @@ case class DeleteResponse(__index: String, __type: String, __id: String, __versi
 case class BulkResponse(took: Long, items: Seq[BulkItemResponse])
 
 @JsonDeserialize(using = classOf[BulkItemResponseDeserializer])
-case class BulkItemResponse(actionType: String, response: DocResponse)
+case class BulkItemResponse(actionType: String, response: AbstractDocResponse)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])

--- a/src/main/scala/com/github/thanhtien522/eshttpclient/entities/BulkItemResponseDeserializer.scala
+++ b/src/main/scala/com/github/thanhtien522/eshttpclient/entities/BulkItemResponseDeserializer.scala
@@ -12,6 +12,7 @@ class BulkItemResponseDeserializer extends JsonDeserializer[BulkItemResponse] {
     val node = p.getCodec.readTree[JsonNode](p)
     node.fieldNames().next() match {
       case "index" => BulkItemResponse("index", p.getCodec.treeToValue(node.get("index"), classOf[IndexResponse]))
+      case "create" => BulkItemResponse("create", p.getCodec.treeToValue(node.get("create"), classOf[IndexResponse]))
       case "update" => BulkItemResponse("update", p.getCodec.treeToValue(node.get("update"), classOf[UpdateResponse]))
       case "delete" => BulkItemResponse("delete", p.getCodec.treeToValue(node.get("delete"), classOf[DeleteResponse]))
       case s => throw new Exception("Deserialize BulkItemResponse failure. Unhandled action name `" + s + "`")

--- a/src/main/scala/com/github/thanhtien522/eshttpclient/entities/ClusterEntities.scala
+++ b/src/main/scala/com/github/thanhtien522/eshttpclient/entities/ClusterEntities.scala
@@ -1,7 +1,7 @@
 package com.github.thanhtien522.eshttpclient.entities
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 /**
@@ -9,9 +9,9 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
   */
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class ClusterInfo(clusterName: String, version: VersionInfo)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(classOf[SnakeCaseStrategy])
+@JsonNaming(classOf[LowerCaseWithUnderscoresStrategy])
 case class VersionInfo(number: String, luceneVersion: String)

--- a/src/test/scala/com/github/thanhtien522/eshttpclient/EsHttpClientBulkTest.scala
+++ b/src/test/scala/com/github/thanhtien522/eshttpclient/EsHttpClientBulkTest.scala
@@ -123,11 +123,13 @@ class EsHttpClientBulkTest extends FunSuite with BeforeAndAfterAll {
       DocIndexRequest(None, None, None, """{"id":98,"type":"facebook share","user_id":111,"date":"2013-03-15 09:42:04.143488"}""")
     )
 
-    val resp = client.bulk(Some(index), Some("events"), requests).items.toArray
-    assert(resp(0).response.status == 400)
-    assert(resp(1).response.status == 400)
-    assert(resp(2).response.status == 201)
-    assert(resp(3).response.status == 201)
+    val resp = client.bulk(Some(index), Some("events"), requests)
+    val items = resp.items.toArray
+    assert(resp.errors)
+    assert(items(0).response.status == 400)
+    assert(items(1).response.status == 400)
+    assert(items(2).response.status == 201)
+    assert(items(3).response.status == 201)
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
- Add base response with `error`, and `status` fields.
- Add AbstractDocResponse with common fields: `index`, `type`, `id`, `version` 
- Add Error entity which supported two types: String (for version 1.x), and Object (version 2.0 and later)
- Also downgrade jackson library to 2.6.5
- Add tests